### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/elftools/construct/__init__.py
+++ b/elftools/construct/__init__.py
@@ -63,7 +63,7 @@ def deprecated(f):
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
         warnings.warn(
-            "This name is deprecated, use %s instead" % f.__name__,
+            "This name is deprecated, use {0!s} instead".format(f.__name__),
             DeprecationWarning, stacklevel=2)
         return f(*args, **kwargs)
     return wrapper

--- a/elftools/construct/adapters.py
+++ b/elftools/construct/adapters.py
@@ -86,7 +86,7 @@ class MappingAdapter(Adapter):
             return self.encoding[obj]
         except (KeyError, TypeError):
             if self.encdefault is NotImplemented:
-                raise MappingError("no encoding mapping for %r [%s]" % (
+                raise MappingError("no encoding mapping for {0!r} [{1!s}]".format(
                     obj, self.subcon.name))
             if self.encdefault is Pass:
                 return obj
@@ -96,7 +96,7 @@ class MappingAdapter(Adapter):
             return self.decoding[obj]
         except (KeyError, TypeError):
             if self.decdefault is NotImplemented:
-                raise MappingError("no decoding mapping for %r [%s]" % (
+                raise MappingError("no decoding mapping for {0!r} [{1!s}]".format(
                     obj, self.subcon.name))
             if self.decdefault is Pass:
                 return obj
@@ -327,10 +327,10 @@ class ConstAdapter(Adapter):
         if obj is None or obj == self.value:
             return self.value
         else:
-            raise ConstError("expected %r, found %r" % (self.value, obj))
+            raise ConstError("expected {0!r}, found {1!r}".format(self.value, obj))
     def _decode(self, obj, context):
         if obj != self.value:
-            raise ConstError("expected %r, found %r" % (self.value, obj))
+            raise ConstError("expected {0!r}, found {1!r}".format(self.value, obj))
         return obj
 
 class SlicingAdapter(Adapter):
@@ -395,7 +395,7 @@ class PaddingAdapter(Adapter):
         if self.strict:
             expected = self._sizeof(context) * self.pattern
             if obj != expected:
-                raise PaddingError("expected %r, found %r" % (expected, obj))
+                raise PaddingError("expected {0!r}, found {1!r}".format(expected, obj))
         return obj
 
 

--- a/elftools/construct/core.py
+++ b/elftools/construct/core.py
@@ -100,7 +100,7 @@ class Construct(object):
         self.conflags = flags
 
     def __repr__(self):
-        return "%s(%r)" % (self.__class__.__name__, self.name)
+        return "{0!s}({1!r})".format(self.__class__.__name__, self.name)
 
     def _set_flag(self, flag):
         """
@@ -290,14 +290,14 @@ def _read_stream(stream, length):
         raise ValueError("length must be >= 0", length)
     data = stream.read(length)
     if len(data) != length:
-        raise FieldError("expected %d, found %d" % (length, len(data)))
+        raise FieldError("expected {0:d}, found {1:d}".format(length, len(data)))
     return data
 
 def _write_stream(stream, length, data):
     if length < 0:
         raise ValueError("length must be >= 0", length)
     if len(data) != length:
-        raise FieldError("expected %d, found %d" % (length, len(data)))
+        raise FieldError("expected {0:d}, found {1:d}".format(length, len(data)))
     stream.write(data)
 
 class StaticField(Construct):
@@ -426,12 +426,12 @@ class MetaArray(Subconstruct):
                     obj.append(self.subcon._parse(stream, context))
                     c += 1
         except ConstructError as ex:
-            raise ArrayError("expected %d, found %d" % (count, c), ex)
+            raise ArrayError("expected {0:d}, found {1:d}".format(count, c), ex)
         return obj
     def _build(self, obj, stream, context):
         count = self.countfunc(context)
         if len(obj) != count:
-            raise ArrayError("expected %d, found %d" % (count, len(obj)))
+            raise ArrayError("expected {0:d}, found {1:d}".format(count, len(obj)))
         if self.subcon.conflags & self.FLAG_COPY_CONTEXT:
             for subobj in obj:
                 self.subcon._build(subobj, stream, context.__copy__())
@@ -507,14 +507,12 @@ class Range(Subconstruct):
                     c += 1
         except ConstructError as ex:
             if c < self.mincount:
-                raise RangeError("expected %d to %d, found %d" %
-                    (self.mincount, self.maxcout, c), ex)
+                raise RangeError("expected {0:d} to {1:d}, found {2:d}".format(self.mincount, self.maxcout, c), ex)
             stream.seek(pos)
         return obj
     def _build(self, obj, stream, context):
         if len(obj) < self.mincount or len(obj) > self.maxcout:
-            raise RangeError("expected %d to %d, found %d" %
-                (self.mincount, self.maxcout, len(obj)))
+            raise RangeError("expected {0:d} to {1:d}, found {2:d}".format(self.mincount, self.maxcout, len(obj)))
         cnt = 0
         try:
             if self.subcon.conflags & self.FLAG_COPY_CONTEXT:
@@ -531,8 +529,7 @@ class Range(Subconstruct):
                     cnt += 1
         except ConstructError as ex:
             if cnt < self.mincount:
-                raise RangeError("expected %d to %d, found %d" %
-                    (self.mincount, self.maxcout, len(obj)), ex)
+                raise RangeError("expected {0:d} to {1:d}, found {2:d}".format(self.mincount, self.maxcout, len(obj)), ex)
     def _sizeof(self, context):
         raise SizeofError("can't calculate size")
 

--- a/elftools/construct/debug.py
+++ b/elftools/construct/debug.py
@@ -45,14 +45,14 @@ class Probe(Construct):
         Construct.__init__(self, None)
         if name is None:
             Probe.counter += 1
-            name = "<unnamed %d>" % (Probe.counter,)
+            name = "<unnamed {0:d}>".format(Probe.counter)
         self.printname = name
         self.show_stream = show_stream
         self.show_context = show_context
         self.show_stack = show_stack
         self.stream_lookahead = stream_lookahead
     def __repr__(self):
-        return "%s(%r)" % (self.__class__.__name__, self.printname)
+        return "{0!s}({1!r})".format(self.__class__.__name__, self.printname)
     def _parse(self, stream, context):
         self.printout(stream, context)
     def _build(self, obj, stream, context):
@@ -125,7 +125,7 @@ class Debugger(Subconstruct):
             self.handle_exc()
     def handle_exc(self, msg = None):
         print("=" * 80)
-        print("Debugging exception of %s:" % (self.subcon,))
+        print("Debugging exception of {0!s}:".format(self.subcon))
         print("".join(traceback.format_exception(*sys.exc_info())[1:]))
         if msg:
             print(msg)

--- a/elftools/construct/lib/bitstream.py
+++ b/elftools/construct/lib/bitstream.py
@@ -73,5 +73,5 @@ class BitStreamWriter(object):
         if not data:
             return
         if type(data) is not str:
-            raise TypeError("data must be a string, not %r" % (type(data),))
+            raise TypeError("data must be a string, not {0!r}".format(type(data)))
         self.buffer.append(data)

--- a/elftools/construct/lib/container.py
+++ b/elftools/construct/lib/container.py
@@ -80,10 +80,10 @@ class Container(MutableMapping):
         return iter(self.__dict__)
 
     def __repr__(self):
-        return "%s(%s)" % (self.__class__.__name__, repr(self.__dict__))
+        return "{0!s}({1!s})".format(self.__class__.__name__, repr(self.__dict__))
 
     def __str__(self):
-        return "%s(%s)" % (self.__class__.__name__, str(self.__dict__))
+        return "{0!s}({1!s})".format(self.__class__.__name__, str(self.__dict__))
 
 class FlagsContainer(Container):
     """
@@ -96,7 +96,7 @@ class FlagsContainer(Container):
     def __str__(self):
         d = dict((k, self[k]) for k in self
                  if self[k] and not k.startswith("_"))
-        return "%s(%s)" % (self.__class__.__name__, pformat(d))
+        return "{0!s}({1!s})".format(self.__class__.__name__, pformat(d))
 
 class ListContainer(list):
     """
@@ -139,7 +139,7 @@ class LazyContainer(object):
             text = self._value.__pretty_str__(nesting, indentation)
         else:
             text = str(self._value)
-        return "%s: %s" % (self.__class__.__name__, text)
+        return "{0!s}: {1!s}".format(self.__class__.__name__, text)
 
     def read(self):
         self.stream.seek(self.pos)

--- a/elftools/construct/lib/hex.py
+++ b/elftools/construct/lib/hex.py
@@ -18,7 +18,7 @@ def hexdump(data, linesize):
     fmt = fmt % (3 * linesize - 1,)
     for i in range(0, len(data), linesize):
         line = data[i : i + linesize]
-        hextext = " ".join('%02x' % byte2int(b) for b in line)
+        hextext = " ".join('{0:02x}'.format(byte2int(b)) for b in line)
         rawtext = "".join(_printable[byte2int(b)] for b in line)
         prettylines.append(fmt % (i, str(hextext), str(rawtext)))
     return prettylines

--- a/elftools/dwarf/callframe.py
+++ b/elftools/dwarf/callframe.py
@@ -187,7 +187,7 @@ class CallFrameInfo(object):
                     struct_parse(structs.Dwarf_uleb128(''), self.stream),
                     struct_parse(structs.Dwarf_sleb128(''), self.stream)]
             else:
-                dwarf_assert(False, 'Unknown CFI opcode: 0x%x' % opcode)
+                dwarf_assert(False, 'Unknown CFI opcode: 0x{0:x}'.format(opcode))
 
             instructions.append(CallFrameInstruction(opcode=opcode, args=args))
             offset = self.stream.tell()
@@ -215,7 +215,7 @@ class CallFrameInstruction(object):
         self.args = args
 
     def __repr__(self):
-        return '%s (0x%x): %s' % (
+        return '{0!s} (0x{1:x}): {2!s}'.format(
             instruction_name(self.opcode), self.opcode, self.args)
 
 
@@ -345,7 +345,7 @@ class CFIEntry(object):
                 _add_to_order(instr.args[0])
                 dwarf_assert(
                     isinstance(self, FDE),
-                    '%s instruction must be in a FDE' % name)
+                    '{0!s} instruction must be in a FDE'.format(name))
                 if instr.args[0] in last_line_in_CIE:
                     cur_line[instr.args[0]] = last_line_in_CIE[instr.args[0]]
                 else:
@@ -393,7 +393,7 @@ class RegisterRule(object):
         self.arg = arg
 
     def __repr__(self):
-        return 'RegisterRule(%s, %s)' % (self.type, self.arg)
+        return 'RegisterRule({0!s}, {1!s})'.format(self.type, self.arg)
 
 
 class CFARule(object):
@@ -406,7 +406,7 @@ class CFARule(object):
         self.expr = expr
 
     def __repr__(self):
-        return 'CFARule(reg=%s, offset=%s, expr=%s)' % (
+        return 'CFARule(reg={0!s}, offset={1!s}, expr={2!s})'.format(
             self.reg, self.offset, self.expr)
 
 

--- a/elftools/dwarf/descriptions.py
+++ b/elftools/dwarf/descriptions.py
@@ -46,14 +46,14 @@ def describe_CFI_instructions(entry):
     def _assert_FDE_instruction(instr):
         dwarf_assert(
             isinstance(entry, FDE),
-            'Unexpected instruction "%s" for a CIE' % instr)
+            'Unexpected instruction "{0!s}" for a CIE'.format(instr))
 
     def _full_reg_name(regnum):
         regname = describe_reg_name(regnum, _MACHINE_ARCH, False)
         if regname:
-            return 'r%s (%s)' % (regnum, regname)
+            return 'r{0!s} ({1!s})'.format(regnum, regname)
         else:
-            return 'r%s' % regnum
+            return 'r{0!s}'.format(regnum)
 
     if isinstance(entry, CIE):
         cie = entry
@@ -68,50 +68,50 @@ def describe_CFI_instructions(entry):
         if name in ('DW_CFA_offset',
                     'DW_CFA_offset_extended', 'DW_CFA_offset_extended_sf',
                     'DW_CFA_val_offset', 'DW_CFA_val_offset_sf'):
-            s += '  %s: %s at cfa%+d\n' % (
+            s += '  {0!s}: {1!s} at cfa{2:+d}\n'.format(
                 name, _full_reg_name(instr.args[0]),
                 instr.args[1] * cie['data_alignment_factor'])
         elif name in (  'DW_CFA_restore', 'DW_CFA_restore_extended',
                         'DW_CFA_undefined', 'DW_CFA_same_value',
                         'DW_CFA_def_cfa_register'):
-            s += '  %s: %s\n' % (name, _full_reg_name(instr.args[0]))
+            s += '  {0!s}: {1!s}\n'.format(name, _full_reg_name(instr.args[0]))
         elif name == 'DW_CFA_register':
-            s += '  %s: %s in %s' % (
+            s += '  {0!s}: {1!s} in {2!s}'.format(
                 name, _full_reg_name(instr.args[0]),
                 _full_reg_name(instr.args[1]))
         elif name == 'DW_CFA_set_loc':
             pc = instr.args[0]
-            s += '  %s: %08x\n' % (name, pc)
+            s += '  {0!s}: {1:08x}\n'.format(name, pc)
         elif name in (  'DW_CFA_advance_loc1', 'DW_CFA_advance_loc2',
                         'DW_CFA_advance_loc4', 'DW_CFA_advance_loc'):
             _assert_FDE_instruction(instr)
             factored_offset = instr.args[0] * cie['code_alignment_factor']
-            s += '  %s: %s to %016x\n' % (
+            s += '  {0!s}: {1!s} to {2:016x}\n'.format(
                 name, factored_offset, factored_offset + pc)
             pc += factored_offset
         elif name in (  'DW_CFA_remember_state', 'DW_CFA_restore_state',
                         'DW_CFA_nop'):
-            s += '  %s\n' % name
+            s += '  {0!s}\n'.format(name)
         elif name == 'DW_CFA_def_cfa':
-            s += '  %s: %s ofs %s\n' % (
+            s += '  {0!s}: {1!s} ofs {2!s}\n'.format(
                 name, _full_reg_name(instr.args[0]), instr.args[1])
         elif name == 'DW_CFA_def_cfa_sf':
-            s += '  %s: %s ofs %s\n' % (
+            s += '  {0!s}: {1!s} ofs {2!s}\n'.format(
                 name, _full_reg_name(instr.args[0]),
                 instr.args[1] * cie['data_alignment_factor'])
         elif name == 'DW_CFA_def_cfa_offset':
-            s += '  %s: %s\n' % (name, instr.args[0])
+            s += '  {0!s}: {1!s}\n'.format(name, instr.args[0])
         elif name == 'DW_CFA_def_cfa_expression':
             expr_dumper = ExprDumper(entry.structs)
             expr_dumper.process_expr(instr.args[0])
-            s += '  %s: (%s)\n' % (name, expr_dumper.get_str())
+            s += '  {0!s}: ({1!s})\n'.format(name, expr_dumper.get_str())
         elif name == 'DW_CFA_expression':
             expr_dumper = ExprDumper(entry.structs)
             expr_dumper.process_expr(instr.args[1])
-            s += '  %s: %s (%s)\n' % (
+            s += '  {0!s}: {1!s} ({2!s})\n'.format(
                 name, _full_reg_name(instr.args[0]), expr_dumper.get_str())
         else:
-            s += '  %s: <??>\n' % name
+            s += '  {0!s}: <??>\n'.format(name)
 
     return s
 
@@ -119,7 +119,7 @@ def describe_CFI_instructions(entry):
 def describe_CFI_register_rule(rule):
     s = _DESCR_CFI_REGISTER_RULE_TYPE[rule.type]
     if rule.type in ('OFFSET', 'VAL_OFFSET'):
-        s += '%+d' % rule.arg
+        s += '{0:+d}'.format(rule.arg)
     elif rule.type == 'REGISTER':
         s += describe_reg_name(rule.arg)
     return s
@@ -129,7 +129,7 @@ def describe_CFI_CFA_rule(rule):
     if rule.expr:
         return 'exp'
     else:
-        return '%s%+d' % (describe_reg_name(rule.reg), rule.offset)
+        return '{0!s}{1:+d}'.format(describe_reg_name(rule.reg), rule.offset)
 
 
 def describe_DWARF_expr(expr, structs):
@@ -162,7 +162,7 @@ def describe_reg_name(regnum, machine_arch=None, default=True):
     elif machine_arch == 'x64':
         return _REG_NAMES_x64[regnum]
     elif default:
-        return 'r%s' % regnum
+        return 'r{0!s}'.format(regnum)
     else:
         return None
 
@@ -186,24 +186,24 @@ _MACHINE_ARCH = None
 
 
 def _describe_attr_ref(attr, die, section_offset):
-    return '<0x%x>' % (attr.value + die.cu.cu_offset)
+    return '<0x{0:x}>'.format((attr.value + die.cu.cu_offset))
 
 def _describe_attr_value_passthrough(attr, die, section_offset):
     return attr.value
 
 def _describe_attr_hex(attr, die, section_offset):
-    return '0x%x' % (attr.value)
+    return '0x{0:x}'.format((attr.value))
 
 def _describe_attr_hex_addr(attr, die, section_offset):
-    return '<0x%x>' % (attr.value)
+    return '<0x{0:x}>'.format((attr.value))
 
 def _describe_attr_split_64bit(attr, die, section_offset):
     low_word = attr.value & 0xFFFFFFFF
     high_word = (attr.value >> 32) & 0xFFFFFFFF
-    return '0x%x 0x%x' % (low_word, high_word)
+    return '0x{0:x} 0x{1:x}'.format(low_word, high_word)
 
 def _describe_attr_strp(attr, die, section_offset):
-    return '(indirect string, offset: 0x%x): %s' % (
+    return '(indirect string, offset: 0x{0:x}): {1!s}'.format(
         attr.raw_value, bytes2str(attr.value))
 
 def _describe_attr_string(attr, die, section_offset):
@@ -222,8 +222,8 @@ def _describe_attr_present(attr, die, section_offset):
     return '1'
 
 def _describe_attr_block(attr, die, section_offset):
-    s = '%s byte block: ' % len(attr.value)
-    s += ' '.join('%x' % item for item in attr.value) + ' '
+    s = '{0!s} byte block: '.format(len(attr.value))
+    s += ' '.join('{0:x}'.format(item) for item in attr.value) + ' '
     return s
 
 
@@ -459,7 +459,7 @@ def _import_extra(attr, die, section_offset):
             with preserve_stream_pos(die.stream):
                 ref_die = DIE(cu, die.stream, ref_die_offset)
             #print '&&& ref_die', ref_die
-            return '[Abbrev Number: %s (%s)]' % (
+            return '[Abbrev Number: {0!s} ({1!s})]'.format(
                 ref_die.abbrev_code, ref_die.tag)
 
     return '[unknown]'
@@ -556,7 +556,7 @@ class ExprDumper(GenericExprVisitor):
             'DW_OP_xderef_size', 'DW_OP_regx',])
 
         for n in range(0, 32):
-            self._ops_with_decimal_arg.add('DW_OP_breg%s' % n)
+            self._ops_with_decimal_arg.add('DW_OP_breg{0!s}'.format(n))
 
         self._ops_with_two_decimal_args = set([
             'DW_OP_const8u', 'DW_OP_const8s', 'DW_OP_bregx', 'DW_OP_bit_piece'])
@@ -571,7 +571,7 @@ class ExprDumper(GenericExprVisitor):
         if len(args) == 0:
             if opcode_name.startswith('DW_OP_reg'):
                 regnum = int(opcode_name[9:])
-                return '%s (%s)' % (
+                return '{0!s} ({1!s})'.format(
                     opcode_name,
                     describe_reg_name(regnum, _MACHINE_ARCH))
             else:
@@ -579,21 +579,21 @@ class ExprDumper(GenericExprVisitor):
         elif opcode_name in self._ops_with_decimal_arg:
             if opcode_name.startswith('DW_OP_breg'):
                 regnum = int(opcode_name[10:])
-                return '%s (%s): %s' % (
+                return '{0!s} ({1!s}): {2!s}'.format(
                     opcode_name,
                     describe_reg_name(regnum, _MACHINE_ARCH),
                     args[0])
             elif opcode_name.endswith('regx'):
                 # applies to both regx and bregx
-                return '%s: %s (%s)' % (
+                return '{0!s}: {1!s} ({2!s})'.format(
                     opcode_name,
                     args[0],
                     describe_reg_name(args[0], _MACHINE_ARCH))
             else:
-                return '%s: %s' % (opcode_name, args[0])
+                return '{0!s}: {1!s}'.format(opcode_name, args[0])
         elif opcode_name in self._ops_with_hex_arg:
-            return '%s: %x' % (opcode_name, args[0])
+            return '{0!s}: {1:x}'.format(opcode_name, args[0])
         elif opcode_name in self._ops_with_two_decimal_args:
-            return '%s: %s %s' % (opcode_name, args[0], args[1])
+            return '{0!s}: {1!s} {2!s}'.format(opcode_name, args[0], args[1])
         else:
-            return '<unknown %s>' % opcode_name
+            return '<unknown {0!s}>'.format(opcode_name)

--- a/elftools/dwarf/die.py
+++ b/elftools/dwarf/die.py
@@ -143,10 +143,10 @@ class DIE(object):
     #------ PRIVATE ------#
 
     def __repr__(self):
-        s = 'DIE %s, size=%s, has_chidren=%s\n' % (
+        s = 'DIE {0!s}, size={1!s}, has_chidren={2!s}\n'.format(
             self.tag, self.size, self.has_children)
         for attrname, attrval in iteritems(self.attributes):
-            s += '    |%-18s:  %s\n' % (attrname, attrval)
+            s += '    |{0:<18!s}:  {1!s}\n'.format(attrname, attrval)
         return s
 
     def __str__(self):

--- a/elftools/dwarf/dwarf_expr.py
+++ b/elftools/dwarf/dwarf_expr.py
@@ -76,7 +76,7 @@ def _generate_dynamic_values(map, prefix, index_start, index_end, value_start):
         [index_start, index_end]. The values start at value_start.
     """
     for index in range(index_start, index_end + 1):
-        name = '%s%s' % (prefix, index)
+        name = '{0!s}{1!s}'.format(prefix, index)
         value = value_start + index - index_start
         map[name] = value
 
@@ -128,7 +128,7 @@ class GenericExprVisitor(object):
             # Decode the opcode and its name
             self._cur_opcode = ord(byte)
             self._cur_opcode_name = DW_OP_opcode2name.get(
-                self._cur_opcode, 'OP:0x%x' % self._cur_opcode)
+                self._cur_opcode, 'OP:0x{0:x}'.format(self._cur_opcode))
             # Will be filled in by visitors
             self._cur_args = [] 
 
@@ -224,9 +224,9 @@ class GenericExprVisitor(object):
             add(opname, self._visit_OP_with_no_args)
 
         for n in range(0, 32):
-            add('DW_OP_lit%s' % n, self._visit_OP_with_no_args)
-            add('DW_OP_reg%s' % n, self._visit_OP_with_no_args)
-            add('DW_OP_breg%s' % n, 
+            add('DW_OP_lit{0!s}'.format(n), self._visit_OP_with_no_args)
+            add('DW_OP_reg{0!s}'.format(n), self._visit_OP_with_no_args)
+            add('DW_OP_breg{0!s}'.format(n), 
                 self._make_visitor_arg_struct(self.structs.Dwarf_sleb128('')))
 
         add('DW_OP_fbreg',

--- a/elftools/dwarf/dwarfinfo.py
+++ b/elftools/dwarf/dwarfinfo.py
@@ -112,7 +112,7 @@ class DWARFInfo(object):
         """
         dwarf_assert(
             offset < self.debug_abbrev_sec.size,
-            "Offset '0x%x' to abbrev table out of section bounds" % offset)
+            "Offset '0x{0:x}' to abbrev table out of section bounds".format(offset))
         if offset not in self._abbrevtable_cache:
             self._abbrevtable_cache[offset] = AbbrevTable(
                 structs=self.structs,
@@ -239,7 +239,7 @@ class DWARFInfo(object):
         cu_die_offset = self.debug_info_sec.stream.tell()
         dwarf_assert(
             self._is_supported_version(cu_header['version']),
-            "Expected supported DWARF version. Got '%s'" % cu_header['version'])
+            "Expected supported DWARF version. Got '{0!s}'".format(cu_header['version']))
         return CompileUnit(
                 header=cu_header,
                 dwarfinfo=self,

--- a/elftools/dwarf/lineprogram.py
+++ b/elftools/dwarf/lineprogram.py
@@ -60,11 +60,11 @@ class LineState(object):
         self.isa = 0
 
     def __repr__(self):
-        a = ['<LineState %x:' % id(self)]
-        a.append('  address = 0x%x' % self.address)
+        a = ['<LineState {0:x}:'.format(id(self))]
+        a.append('  address = 0x{0:x}'.format(self.address))
         for attr in ('file', 'line', 'column', 'is_stmt', 'basic_block',
                      'end_sequence', 'prologue_end', 'epilogue_begin', 'isa'):
-            a.append('  %s = %s' % (attr, getattr(self, attr)))
+            a.append('  {0!s} = {1!s}'.format(attr, getattr(self, attr)))
         return '\n'.join(a) + '>\n'
 
 
@@ -248,8 +248,8 @@ class LineProgram(object):
                     state.isa = operand
                     add_entry_old_state(opcode, [operand])
                 else:
-                    dwarf_assert(False, 'Invalid standard line program opcode: %s' % (
-                        opcode,))
+                    dwarf_assert(False, 'Invalid standard line program opcode: {0!s}'.format(
+                        opcode))
             offset = self.stream.tell()
         return entries
 

--- a/elftools/dwarf/structs.py
+++ b/elftools/dwarf/structs.py
@@ -291,8 +291,8 @@ class _InitialLengthAdapter(Adapter):
             if obj.first == 0xFFFFFFFF:
                 return obj.second
             else:
-                raise ConstructError("Failed decoding initial length for %X" % (
-                    obj.first))
+                raise ConstructError("Failed decoding initial length for {0:X}".format((
+                    obj.first)))
 
 
 def _LEB128_reader():

--- a/elftools/elf/descriptions.py
+++ b/elftools/elf/descriptions.py
@@ -21,7 +21,7 @@ def describe_ei_data(x):
     return _DESCR_EI_DATA.get(x, _unknown)
 
 def describe_ei_version(x):
-    s = '%d' % ENUM_E_VERSION[x]
+    s = '{0:d}'.format(ENUM_E_VERSION[x])
     if x == 'EV_CURRENT':
         s += ' (current)'
     return s
@@ -36,7 +36,7 @@ def describe_e_machine(x):
     return _DESCR_E_MACHINE.get(x, _unknown)
 
 def describe_e_version_numeric(x):
-    return '0x%x' % ENUM_E_VERSION[x]
+    return '0x{0:x}'.format(ENUM_E_VERSION[x])
 
 def describe_p_type(x):
     if x in _DESCR_P_TYPE:
@@ -80,7 +80,7 @@ def describe_symbol_visibility(x):
     return _DESCR_ST_VISIBILITY.get(x, _unknown)
 
 def describe_symbol_shndx(x):
-    return _DESCR_ST_SHNDX.get(x, '%3s' % x)
+    return _DESCR_ST_SHNDX.get(x, '{0:3!s}'.format(x))
 
 def describe_reloc_type(x, elffile):
     arch = elffile.get_machine_arch()
@@ -95,7 +95,7 @@ def describe_reloc_type(x, elffile):
     elif arch == 'MIPS':
         return _DESCR_RELOC_TYPE_MIPS.get(x, _unknown)
     else:
-        return 'unrecognized: %-7x' % (x & 0xFFFFFFFF)
+        return 'unrecognized: {0:<7x}'.format((x & 0xFFFFFFFF))
 
 def describe_dyn_tag(x):
     return _DESCR_D_TAG.get(x, _unknown)
@@ -115,7 +115,7 @@ def describe_syminfo_flags(x):
         SUNW_SYMINFO_FLAGS.SYMINFO_FLG_DEFERRED) if x & flag)
 
 def describe_symbol_boundto(x):
-    return _DESCR_SYMINFO_BOUNDTO.get(x, '%3s' % x)
+    return _DESCR_SYMINFO_BOUNDTO.get(x, '{0:3!s}'.format(x))
 
 def describe_ver_flags(x):
     return ' | '.join(_DESCR_VER_FLAGS[flag] for flag in (
@@ -127,17 +127,17 @@ def describe_note(x):
   n_desc = x['n_desc']
   desc = ''
   if x['n_type'] == 'NT_GNU_ABI_TAG':
-      desc = '\n    OS: %s, ABI: %d.%d.%d' % (
+      desc = '\n    OS: {0!s}, ABI: {1:d}.{2:d}.{3:d}'.format(
           _DESCR_NOTE_ABI_TAG_OS.get(n_desc['abi_os'], _unknown),
           n_desc['abi_major'], n_desc['abi_minor'], n_desc['abi_tiny'])
   elif x['n_type'] == 'NT_GNU_BUILD_ID':
-      desc = '\n    Build ID: %s' % (n_desc)
+      desc = '\n    Build ID: {0!s}'.format((n_desc))
 
   note_type = (x['n_type'] if isinstance(x['n_type'], str)
                else 'Unknown note type:')
-  note_type_desc = ('0x%.8x' % x['n_type'] if isinstance(x['n_type'], int) else
+  note_type_desc = ('0x{0:.8x}'.format(x['n_type']) if isinstance(x['n_type'], int) else
                     _DESCR_NOTE_N_TYPE.get(x['n_type'], _unknown))
-  return '%s (%s)%s' % (note_type, note_type_desc, desc)
+  return '{0!s} ({1!s}){2!s}'.format(note_type, note_type_desc, desc)
 
 #-------------------------------------------------------------------------------
 _unknown = '<unknown>'

--- a/elftools/elf/dynamic.py
+++ b/elftools/elf/dynamic.py
@@ -56,14 +56,14 @@ class DynamicTag(object):
         return self.entry[name]
 
     def __repr__(self):
-        return '<DynamicTag (%s): %r>' % (self.entry.d_tag, self.entry)
+        return '<DynamicTag ({0!s}): {1!r}>'.format(self.entry.d_tag, self.entry)
 
     def __str__(self):
         if self.entry.d_tag in self._HANDLED_TAGS:
-            s = '"%s"' % getattr(self, self.entry.d_tag[3:].lower())
+            s = '"{0!s}"'.format(getattr(self, self.entry.d_tag[3:].lower()))
         else:
-            s = '%#x' % self.entry.d_ptr
-        return '<DynamicTag (%s) %s>' % (self.entry.d_tag, s)
+            s = '{0:#x}'.format(self.entry.d_ptr)
+        return '<DynamicTag ({0!s}) {1!s}>'.format(self.entry.d_tag, s)
 
 
 class Dynamic(object):
@@ -210,8 +210,7 @@ class DynamicSegment(Segment, Dynamic):
                 if symbol_size != tag['d_val']:
                     # DT_SYMENT is the size of one symbol entry. It must be the
                     # same as returned by Elf_Sym.sizeof.
-                    raise ELFError('DT_SYMENT (%d) != Elf_Sym (%d).' %
-                                   (tag['d_val'], symbol_size))
+                    raise ELFError('DT_SYMENT ({0:d}) != Elf_Sym ({1:d}).'.format(tag['d_val'], symbol_size))
             if (tag_ptr > tab_ptr and
                     (nearest_ptr is None or nearest_ptr > tag_ptr)):
                 nearest_ptr = tag_ptr

--- a/elftools/elf/elffile.py
+++ b/elftools/elf/elffile.py
@@ -206,7 +206,7 @@ class ELFFile(object):
         elif ei_class == b'\x02':
             self.elfclass = 64
         else:
-            raise ELFError('Invalid EI_CLASS %s' % repr(ei_class))
+            raise ELFError('Invalid EI_CLASS {0!s}'.format(repr(ei_class)))
 
         ei_data = self.stream.read(1)
         if ei_data == b'\x01':
@@ -214,7 +214,7 @@ class ELFFile(object):
         elif ei_data == b'\x02':
             self.little_endian = False
         else:
-            raise ELFError('Invalid EI_DATA %s' % repr(ei_data))
+            raise ELFError('Invalid EI_DATA {0!s}'.format(repr(ei_data)))
 
     def _section_offset(self, n):
         """ Compute the offset of section #n in the file

--- a/elftools/elf/relocation.py
+++ b/elftools/elf/relocation.py
@@ -35,7 +35,7 @@ class Relocation(object):
         return self.entry[name]
 
     def __repr__(self):
-        return '<Relocation (%s): %s>' % (
+        return '<Relocation ({0!s}): {1!s}>'.format(
                 'RELA' if self.is_RELA() else 'REL',
                 self.entry)
 
@@ -61,7 +61,7 @@ class RelocationSection(Section):
 
         elf_assert(
             self.header['sh_entsize'] == expected_size,
-            'Expected sh_entsize of SHT_REL section to be %s' % expected_size)
+            'Expected sh_entsize of SHT_REL section to be {0!s}'.format(expected_size))
 
     def is_RELA(self):
         """ Is this a RELA relocation section? If not, it's REL.
@@ -130,8 +130,8 @@ class RelocationHandler(object):
         # All peppered with some sanity checking.
         if reloc['r_info_sym'] >= symtab.num_symbols():
             raise ELFRelocationError(
-                'Invalid symbol reference in relocation: index %s' % (
-                    reloc['r_info_sym']))
+                'Invalid symbol reference in relocation: index {0!s}'.format((
+                    reloc['r_info_sym'])))
         sym_value = symtab.get_symbol(reloc['r_info_sym'])['st_value']
 
         reloc_type = reloc['r_info_type']
@@ -140,22 +140,22 @@ class RelocationHandler(object):
         if self.elffile.get_machine_arch() == 'x86':
             if reloc.is_RELA():
                 raise ELFRelocationError(
-                    'Unexpected RELA relocation for x86: %s' % reloc)
+                    'Unexpected RELA relocation for x86: {0!s}'.format(reloc))
             recipe = self._RELOCATION_RECIPES_X86.get(reloc_type, None)
         elif self.elffile.get_machine_arch() == 'x64':
             if not reloc.is_RELA():
                 raise ELFRelocationError(
-                    'Unexpected REL relocation for x64: %s' % reloc)
+                    'Unexpected REL relocation for x64: {0!s}'.format(reloc))
             recipe = self._RELOCATION_RECIPES_X64.get(reloc_type, None)
         elif self.elffile.get_machine_arch() == 'MIPS':
             if reloc.is_RELA():
                 raise ELFRelocationError(
-                    'Unexpected RELA relocation for MIPS: %s' % reloc)
+                    'Unexpected RELA relocation for MIPS: {0!s}'.format(reloc))
             recipe = self._RELOCATION_RECIPES_MIPS.get(reloc_type, None)
 
         if recipe is None:
             raise ELFRelocationError(
-                    'Unsupported relocation type: %s' % reloc_type)
+                    'Unsupported relocation type: {0!s}'.format(reloc_type))
 
         # So now we have everything we need to actually perform the relocation.
         # Let's get to it:
@@ -167,8 +167,8 @@ class RelocationHandler(object):
         elif recipe.bytesize == 8:
             value_struct = self.elffile.structs.Elf_word64('')
         else:
-            raise ELFRelocationError('Invalid bytesize %s for relocation' %
-                    recipe_bytesize)
+            raise ELFRelocationError('Invalid bytesize {0!s} for relocation'.format(
+                    recipe_bytesize))
 
         # 1. Read the value from the stream (with correct size and endianness)
         original_value = struct_parse(

--- a/elftools/elf/sections.py
+++ b/elftools/elf/sections.py
@@ -78,9 +78,9 @@ class SymbolTableSection(Section):
         self.elfstructs = self.elffile.structs
         self.stringtable = stringtable
         elf_assert(self['sh_entsize'] > 0,
-                'Expected entry size of section %r to be > 0' % name)
+                'Expected entry size of section {0!r} to be > 0'.format(name))
         elf_assert(self['sh_size'] % self['sh_entsize'] == 0,
-                'Expected section size to be a multiple of entry size in section %r' % name)
+                'Expected section size to be a multiple of entry size in section {0!r}'.format(name))
         self._symbol_name_map = None
 
     def num_symbols(self):

--- a/elftools/elf/segments.py
+++ b/elftools/elf/segments.py
@@ -129,7 +129,7 @@ class NoteSegment(Segment):
                                               self.stream,
                                               offset)
             elif note['n_type'] == 'NT_GNU_BUILD_ID':
-                note['n_desc'] = ''.join('%.2x' % ord(b) for b in desc_data)
+                note['n_desc'] = ''.join('{0:.2x}'.format(ord(b)) for b in desc_data)
             else:
                 note['n_desc'] = desc_data
             offset += roundup(note['n_descsz'], 2)

--- a/examples/dwarf_die_tree.py
+++ b/examples/dwarf_die_tree.py
@@ -36,15 +36,15 @@ def process_file(filename):
             # computed attributes (such as its offset in the section) and
             # a header which conforms to the DWARF standard. The access to
             # header elements is, as usual, via item-lookup.
-            print('  Found a compile unit at offset %s, length %s' % (
+            print('  Found a compile unit at offset {0!s}, length {1!s}'.format(
                 CU.cu_offset, CU['unit_length']))
 
             # Start with the top DIE, the root for this CU's DIE tree
             top_DIE = CU.get_top_DIE()
-            print('    Top DIE with tag=%s' % top_DIE.tag)
+            print('    Top DIE with tag={0!s}'.format(top_DIE.tag))
 
             # We're interested in the filename...
-            print('    name=%s' % top_DIE.get_full_path())
+            print('    name={0!s}'.format(top_DIE.get_full_path()))
 
             # Display DIEs recursively starting with top_DIE
             die_info_rec(top_DIE)
@@ -54,7 +54,7 @@ def die_info_rec(die, indent_level='    '):
     """ A recursive function for showing information about a DIE and its
         children.
     """
-    print(indent_level + 'DIE tag=%s' % die.tag)
+    print(indent_level + 'DIE tag={0!s}'.format(die.tag))
     child_indent = indent_level + '  '
     for child in die.iter_children():
         die_info_rec(child, child_indent)

--- a/examples/dwarf_location_lists.py
+++ b/examples/dwarf_location_lists.py
@@ -49,7 +49,7 @@ def process_file(filename):
             # computed attributes (such as its offset in the section) and
             # a header which conforms to the DWARF standard. The access to
             # header elements is, as usual, via item-lookup.
-            print('  Found a compile unit at offset %s, length %s' % (
+            print('  Found a compile unit at offset {0!s}, length {1!s}'.format(
                 CU.cu_offset, CU['unit_length']))
 
             # A CU provides a simple API to iterate over all the DIEs in it.
@@ -65,7 +65,7 @@ def process_file(filename):
                         loclist = location_lists.get_location_list_at_offset(
                             attr.value)
 
-                        print('   DIE %s. attr %s.\n%s' % (
+                        print('   DIE {0!s}. attr {1!s}.\n{2!s}'.format(
                             DIE.tag,
                             attr.name,
                             show_loclist(loclist, dwarfinfo, indent='      ')))
@@ -78,7 +78,7 @@ def show_loclist(loclist, dwarfinfo, indent):
     d = []
     for loc_entity in loclist:
         if isinstance(loc_entity, LocationEntry):
-            d.append('%s <<%s>>' % (
+            d.append('{0!s} <<{1!s}>>'.format(
                 loc_entity,
                 describe_DWARF_expr(loc_entity.loc_expr, dwarfinfo.structs)))
         else:

--- a/examples/dwarf_range_lists.py
+++ b/examples/dwarf_range_lists.py
@@ -47,7 +47,7 @@ def process_file(filename):
             # computed attributes (such as its offset in the section) and
             # a header which conforms to the DWARF standard. The access to
             # header elements is, as usual, via item-lookup.
-            print('  Found a compile unit at offset %s, length %s' % (
+            print('  Found a compile unit at offset {0!s}, length {1!s}'.format(
                 CU.cu_offset, CU['unit_length']))
 
             # A CU provides a simple API to iterate over all the DIEs in it.
@@ -63,7 +63,7 @@ def process_file(filename):
                         rangelist = range_lists.get_range_list_at_offset(
                             attr.value)
 
-                        print('   DIE %s. attr %s.\n%s' % (
+                        print('   DIE {0!s}. attr {1!s}.\n{2!s}'.format(
                             DIE.tag,
                             attr.name,
                             rangelist))

--- a/examples/elf_low_high_api.py
+++ b/examples/elf_low_high_api.py
@@ -34,7 +34,7 @@ def section_info_lowlevel(stream):
     elffile = ELFFile(stream)
 
     # The e_shnum ELF header field says how many sections there are in a file
-    print('  %s sections' % elffile['e_shnum'])
+    print('  {0!s} sections'.format(elffile['e_shnum']))
 
     # Try to find the symbol table
     for i in range(elffile['e_shnum']):
@@ -48,7 +48,7 @@ def section_info_lowlevel(stream):
             # here. To get to the actual name one would need to parse the string
             # table section and extract the name from there (or use the
             # high-level API!)
-            print('  Section name: %s, type: %s' % (
+            print('  Section name: {0!s}, type: {1!s}'.format(
                     section_header['sh_name'], section_header['sh_type']))
             break
     else:
@@ -61,7 +61,7 @@ def section_info_highlevel(stream):
 
     # Just use the public methods of ELFFile to get what we need
     # Note that section names are strings.
-    print('  %s sections' % elffile.num_sections())
+    print('  {0!s} sections'.format(elffile.num_sections()))
     section = elffile.get_section_by_name('.symtab')
 
     if not section:
@@ -70,7 +70,7 @@ def section_info_highlevel(stream):
 
     # A section type is in its header, but the name was decoded and placed in
     # a public attribute.
-    print('  Section name: %s, type: %s' %(
+    print('  Section name: {0!s}, type: {1!s}'.format(
         section.name, section['sh_type']))
 
     # But there's more... If this section is a symbol table section (which is
@@ -78,9 +78,9 @@ def section_info_highlevel(stream):
     # get some more information about it.
     if isinstance(section, SymbolTableSection):
         num_symbols = section.num_symbols()
-        print("  It's a symbol section with %s symbols" % num_symbols)
-        print("  The name of the last symbol in the section is: %s" % (
-            section.get_symbol(num_symbols - 1).name))
+        print("  It's a symbol section with {0!s} symbols".format(num_symbols))
+        print("  The name of the last symbol in the section is: {0!s}".format((
+            section.get_symbol(num_symbols - 1).name)))
 
 
 if __name__ == '__main__':

--- a/examples/elf_relocations.py
+++ b/examples/elf_relocations.py
@@ -30,15 +30,15 @@ def process_file(filename):
         reladyn = elffile.get_section_by_name(reladyn_name)
 
         if not isinstance(reladyn, RelocationSection):
-            print('  The file has no %s section' % reladyn_name)
+            print('  The file has no {0!s} section'.format(reladyn_name))
 
-        print('  %s section with %s relocations' % (
+        print('  {0!s} section with {1!s} relocations'.format(
             reladyn_name, reladyn.num_relocations()))
 
         for reloc in reladyn.iter_relocations():
-            print('    Relocation (%s)' % 'RELA' if reloc.is_RELA() else 'REL')
+            print('    Relocation ({0!s})'.format('RELA') if reloc.is_RELA() else 'REL')
             # Relocation entry attributes are available through item lookup
-            print('      offset = %s' % reloc['r_offset'])
+            print('      offset = {0!s}'.format(reloc['r_offset']))
 
 
 if __name__ == '__main__':

--- a/examples/elfclass_address_size.py
+++ b/examples/elfclass_address_size.py
@@ -21,14 +21,14 @@ def process_file(filename):
     with open(filename, 'rb') as f:
         elffile = ELFFile(f)
         # elfclass is a public attribute of ELFFile, read from its header
-        print('%s: elfclass is %s' % (filename, elffile.elfclass))
+        print('{0!s}: elfclass is {1!s}'.format(filename, elffile.elfclass))
 
         if elffile.has_dwarf_info():
             dwarfinfo = elffile.get_dwarf_info()
             for CU in dwarfinfo.iter_CUs():
                 # cu_offset is a public attribute of CU
                 # address_size is part of the CU header
-                print('  CU at offset 0x%x. address_size is %s' % (
+                print('  CU at offset 0x{0:x}. address_size is {1!s}'.format(
                     CU.cu_offset, CU['address_size']))
 
 

--- a/examples/examine_dwarf_info.py
+++ b/examples/examine_dwarf_info.py
@@ -35,15 +35,15 @@ def process_file(filename):
             # computed attributes (such as its offset in the section) and
             # a header which conforms to the DWARF standard. The access to
             # header elements is, as usual, via item-lookup.
-            print('  Found a compile unit at offset %s, length %s' % (
+            print('  Found a compile unit at offset {0!s}, length {1!s}'.format(
                 CU.cu_offset, CU['unit_length']))
 
             # The first DIE in each compile unit describes it.
             top_DIE = CU.get_top_DIE()
-            print('    Top DIE with tag=%s' % top_DIE.tag)
+            print('    Top DIE with tag={0!s}'.format(top_DIE.tag))
 
             # We're interested in the filename...
-            print('    name=%s' % top_DIE.get_full_path())
+            print('    name={0!s}'.format(top_DIE.get_full_path()))
 
 if __name__ == '__main__':
     if sys.argv[1] == '--test':

--- a/scripts/readelf.py
+++ b/scripts/readelf.py
@@ -74,49 +74,48 @@ class ReadElf(object):
         """
         self._emitline('ELF Header:')
         self._emit('  Magic:   ')
-        self._emitline(' '.join('%2.2x' % byte2int(b)
+        self._emitline(' '.join('{0:2.2x}'.format(byte2int(b))
                                     for b in self.elffile.e_ident_raw))
         header = self.elffile.header
         e_ident = header['e_ident']
-        self._emitline('  Class:                             %s' %
-                describe_ei_class(e_ident['EI_CLASS']))
-        self._emitline('  Data:                              %s' %
-                describe_ei_data(e_ident['EI_DATA']))
-        self._emitline('  Version:                           %s' %
-                describe_ei_version(e_ident['EI_VERSION']))
-        self._emitline('  OS/ABI:                            %s' %
-                describe_ei_osabi(e_ident['EI_OSABI']))
-        self._emitline('  ABI Version:                       %d' %
-                e_ident['EI_ABIVERSION'])
-        self._emitline('  Type:                              %s' %
-                describe_e_type(header['e_type']))
-        self._emitline('  Machine:                           %s' %
-                describe_e_machine(header['e_machine']))
-        self._emitline('  Version:                           %s' %
-                describe_e_version_numeric(header['e_version']))
-        self._emitline('  Entry point address:               %s' %
-                self._format_hex(header['e_entry']))
-        self._emit('  Start of program headers:          %s' %
-                header['e_phoff'])
+        self._emitline('  Class:                             {0!s}'.format(
+                describe_ei_class(e_ident['EI_CLASS'])))
+        self._emitline('  Data:                              {0!s}'.format(
+                describe_ei_data(e_ident['EI_DATA'])))
+        self._emitline('  Version:                           {0!s}'.format(
+                describe_ei_version(e_ident['EI_VERSION'])))
+        self._emitline('  OS/ABI:                            {0!s}'.format(
+                describe_ei_osabi(e_ident['EI_OSABI'])))
+        self._emitline('  ABI Version:                       {0:d}'.format(
+                e_ident['EI_ABIVERSION']))
+        self._emitline('  Type:                              {0!s}'.format(
+                describe_e_type(header['e_type'])))
+        self._emitline('  Machine:                           {0!s}'.format(
+                describe_e_machine(header['e_machine'])))
+        self._emitline('  Version:                           {0!s}'.format(
+                describe_e_version_numeric(header['e_version'])))
+        self._emitline('  Entry point address:               {0!s}'.format(
+                self._format_hex(header['e_entry'])))
+        self._emit('  Start of program headers:          {0!s}'.format(
+                header['e_phoff']))
         self._emitline(' (bytes into file)')
-        self._emit('  Start of section headers:          %s' %
-                header['e_shoff'])
+        self._emit('  Start of section headers:          {0!s}'.format(
+                header['e_shoff']))
         self._emitline(' (bytes into file)')
-        self._emitline('  Flags:                             %s%s' %
-                (self._format_hex(header['e_flags']),
+        self._emitline('  Flags:                             {0!s}{1!s}'.format(self._format_hex(header['e_flags']),
                 self.decode_flags(header['e_flags'])))
-        self._emitline('  Size of this header:               %s (bytes)' %
-                header['e_ehsize'])
-        self._emitline('  Size of program headers:           %s (bytes)' %
-                header['e_phentsize'])
-        self._emitline('  Number of program headers:         %s' %
-                header['e_phnum'])
-        self._emitline('  Size of section headers:           %s (bytes)' %
-                header['e_shentsize'])
-        self._emitline('  Number of section headers:         %s' %
-                header['e_shnum'])
-        self._emitline('  Section header string table index: %s' %
-                header['e_shstrndx'])
+        self._emitline('  Size of this header:               {0!s} (bytes)'.format(
+                header['e_ehsize']))
+        self._emitline('  Size of program headers:           {0!s} (bytes)'.format(
+                header['e_phentsize']))
+        self._emitline('  Number of program headers:         {0!s}'.format(
+                header['e_phnum']))
+        self._emitline('  Size of section headers:           {0!s} (bytes)'.format(
+                header['e_shentsize']))
+        self._emitline('  Number of section headers:         {0!s}'.format(
+                header['e_shnum']))
+        self._emitline('  Section header string table index: {0!s}'.format(
+                header['e_shstrndx']))
 
     def decode_flags(self, flags):
         description = ""
@@ -151,13 +150,13 @@ class ReadElf(object):
 
         elfheader = self.elffile.header
         if show_heading:
-            self._emitline('Elf file type is %s' %
-                describe_e_type(elfheader['e_type']))
-            self._emitline('Entry point is %s' %
-                self._format_hex(elfheader['e_entry']))
+            self._emitline('Elf file type is {0!s}'.format(
+                describe_e_type(elfheader['e_type'])))
+            self._emitline('Entry point is {0!s}'.format(
+                self._format_hex(elfheader['e_entry'])))
             # readelf weirness - why isn't e_phoff printed as hex? (for section
             # headers, it is...)
-            self._emitline('There are %s program headers, starting at offset %s' % (
+            self._emitline('There are {0!s} program headers, starting at offset {1!s}'.format(
                 elfheader['e_phnum'], elfheader['e_phoff']))
             self._emitline()
 
@@ -178,10 +177,10 @@ class ReadElf(object):
         # Now the entries
         #
         for segment in self.elffile.iter_segments():
-            self._emit('  %-14s ' % describe_p_type(segment['p_type']))
+            self._emit('  {0:<14!s} '.format(describe_p_type(segment['p_type'])))
 
             if self.elffile.elfclass == 32:
-                self._emitline('%s %s %s %s %s %-3s %s' % (
+                self._emitline('{0!s} {1!s} {2!s} {3!s} {4!s} {5:<3!s} {6!s}'.format(
                     self._format_hex(segment['p_offset'], fieldsize=6),
                     self._format_hex(segment['p_vaddr'], fullhex=True),
                     self._format_hex(segment['p_paddr'], fullhex=True),
@@ -190,11 +189,11 @@ class ReadElf(object):
                     describe_p_flags(segment['p_flags']),
                     self._format_hex(segment['p_align'])))
             else: # 64
-                self._emitline('%s %s %s' % (
+                self._emitline('{0!s} {1!s} {2!s}'.format(
                     self._format_hex(segment['p_offset'], fullhex=True),
                     self._format_hex(segment['p_vaddr'], fullhex=True),
                     self._format_hex(segment['p_paddr'], fullhex=True)))
-                self._emitline('                 %s %s  %-3s    %s' % (
+                self._emitline('                 {0!s} {1!s}  {2:<3!s}    {3!s}'.format(
                     self._format_hex(segment['p_filesz'], fullhex=True),
                     self._format_hex(segment['p_memsz'], fullhex=True),
                     describe_p_flags(segment['p_flags']),
@@ -203,8 +202,8 @@ class ReadElf(object):
                     self._format_hex(segment['p_align'], lead0x=False)))
 
             if isinstance(segment, InterpSegment):
-                self._emitline('      [Requesting program interpreter: %s]' %
-                    segment.get_interp_name())
+                self._emitline('      [Requesting program interpreter: {0!s}]'.format(
+                    segment.get_interp_name()))
 
         # Sections to segments mapping
         #
@@ -216,12 +215,12 @@ class ReadElf(object):
         self._emitline('  Segment Sections...')
 
         for nseg, segment in enumerate(self.elffile.iter_segments()):
-            self._emit('   %2.2d     ' % nseg)
+            self._emit('   {0:2.2d}     '.format(nseg))
 
             for section in self.elffile.iter_sections():
                 if (    not section.is_null() and
                         segment.section_in_segment(section)):
-                    self._emit('%s ' % section.name)
+                    self._emit('{0!s} '.format(section.name))
 
             self._emitline('')
 
@@ -230,11 +229,11 @@ class ReadElf(object):
         """
         elfheader = self.elffile.header
         if show_heading:
-            self._emitline('There are %s section headers, starting at offset %s' % (
+            self._emitline('There are {0!s} section headers, starting at offset {1!s}'.format(
                 elfheader['e_shnum'], self._format_hex(elfheader['e_shoff'])))
 
-        self._emitline('\nSection Header%s:' % (
-            's' if elfheader['e_shnum'] > 1 else ''))
+        self._emitline('\nSection Header{0!s}:'.format((
+            's' if elfheader['e_shnum'] > 1 else '')))
 
         # Different formatting constraints of 32-bit and 64-bit addresses
         #
@@ -247,11 +246,11 @@ class ReadElf(object):
         # Now the entries
         #
         for nsec, section in enumerate(self.elffile.iter_sections()):
-            self._emit('  [%2u] %-17.17s %-15.15s ' % (
+            self._emit('  [{0:2d}] {1:<17.17!s} {2:<15.15!s} '.format(
                 nsec, section.name, describe_sh_type(section['sh_type'])))
 
             if self.elffile.elfclass == 32:
-                self._emitline('%s %s %s %s %3s %2s %3s %2s' % (
+                self._emitline('{0!s} {1!s} {2!s} {3!s} {4:3!s} {5:2!s} {6:3!s} {7:2!s}'.format(
                     self._format_hex(section['sh_addr'], fieldsize=8, lead0x=False),
                     self._format_hex(section['sh_offset'], fieldsize=6, lead0x=False),
                     self._format_hex(section['sh_size'], fieldsize=6, lead0x=False),
@@ -260,12 +259,12 @@ class ReadElf(object):
                     section['sh_link'], section['sh_info'],
                     section['sh_addralign']))
             else: # 64
-                self._emitline(' %s  %s' % (
+                self._emitline(' {0!s}  {1!s}'.format(
                     self._format_hex(section['sh_addr'], fullhex=True, lead0x=False),
                     self._format_hex(section['sh_offset'],
                         fieldsize=16 if section['sh_offset'] > 0xffffffff else 8,
                         lead0x=False)))
-                self._emitline('       %s  %s %3s      %2s   %3s     %s' % (
+                self._emitline('       {0!s}  {1!s} {2:3!s}      {3:2!s}   {4:3!s}     {5!s}'.format(
                     self._format_hex(section['sh_size'], fullhex=True, lead0x=False),
                     self._format_hex(section['sh_entsize'], fullhex=True, lead0x=False),
                     describe_sh_flags(section['sh_flags']),
@@ -291,11 +290,11 @@ class ReadElf(object):
                 continue
 
             if section['sh_entsize'] == 0:
-                self._emitline("\nSymbol table '%s' has a sh_entsize of zero!" % (
-                    section.name))
+                self._emitline("\nSymbol table '{0!s}' has a sh_entsize of zero!".format((
+                    section.name)))
                 continue
 
-            self._emitline("\nSymbol table '%s' contains %s entries:" % (
+            self._emitline("\nSymbol table '{0!s}' contains {1!s} entries:".format(
                 section.name, section.num_symbols()))
 
             if self.elffile.elfclass == 32:
@@ -315,16 +314,16 @@ class ReadElf(object):
                                                  'VER_NDX_GLOBAL')):
                         if version['filename']:
                             # external symbol
-                            version_info = '@%(name)s (%(index)i)' % version
+                            version_info = '@{name!s} ({index:d})'.format(**version)
                         else:
                             # internal symbol
                             if version['hidden']:
-                                version_info = '@%(name)s' % version
+                                version_info = '@{name!s}'.format(**version)
                             else:
-                                version_info = '@@%(name)s' % version
+                                version_info = '@@{name!s}'.format(**version)
 
                 # symbol names are truncated to 25 chars, similarly to readelf
-                self._emitline('%6d: %s %5d %-7s %-6s %-7s %4s %.25s%s' % (
+                self._emitline('{0:6d}: {1!s} {2:5d} {3:<7!s} {4:<6!s} {5:<7!s} {6:4!s} {7:.25!s}{8!s}'.format(
                     nsym,
                     self._format_hex(
                         symbol['st_value'], fullhex=True, lead0x=False),
@@ -345,7 +344,7 @@ class ReadElf(object):
                 continue
 
             has_dynamic_sections = True
-            self._emitline("\nDynamic section at offset %s contains %s entries:" % (
+            self._emitline("\nDynamic section at offset {0!s} contains {1!s} entries:".format(
                 self._format_hex(section['sh_offset']),
                 section.num_tags()))
             self._emitline("  Tag        Type                         Name/Value")
@@ -353,30 +352,30 @@ class ReadElf(object):
             padding = 20 + (8 if self.elffile.elfclass == 32 else 0)
             for tag in section.iter_tags():
                 if tag.entry.d_tag == 'DT_NEEDED':
-                    parsed = 'Shared library: [%s]' % tag.needed
+                    parsed = 'Shared library: [{0!s}]'.format(tag.needed)
                 elif tag.entry.d_tag == 'DT_RPATH':
-                    parsed = 'Library rpath: [%s]' % tag.rpath
+                    parsed = 'Library rpath: [{0!s}]'.format(tag.rpath)
                 elif tag.entry.d_tag == 'DT_RUNPATH':
-                    parsed = 'Library runpath: [%s]' % tag.runpath
+                    parsed = 'Library runpath: [{0!s}]'.format(tag.runpath)
                 elif tag.entry.d_tag == 'DT_SONAME':
-                    parsed = 'Library soname: [%s]' % tag.soname
+                    parsed = 'Library soname: [{0!s}]'.format(tag.soname)
                 elif tag.entry.d_tag.endswith(('SZ', 'ENT')):
-                    parsed = '%i (bytes)' % tag['d_val']
+                    parsed = '{0:d} (bytes)'.format(tag['d_val'])
                 elif tag.entry.d_tag.endswith(('NUM', 'COUNT')):
-                    parsed = '%i' % tag['d_val']
+                    parsed = '{0:d}'.format(tag['d_val'])
                 elif tag.entry.d_tag == 'DT_PLTREL':
                     s = describe_dyn_tag(tag.entry.d_val)
                     if s.startswith('DT_'):
                         s = s[3:]
-                    parsed = '%s' % s
+                    parsed = '{0!s}'.format(s)
                 else:
-                    parsed = '%#x' % tag['d_val']
+                    parsed = '{0:#x}'.format(tag['d_val'])
 
                 self._emitline(" %s %-*s %s" % (
                     self._format_hex(ENUM_D_TAG.get(tag.entry.d_tag, tag.entry.d_tag),
                         fullhex=True, lead0x=True),
                     padding,
-                    '(%s)' % (tag.entry.d_tag[3:],),
+                    '({0!s})'.format(tag.entry.d_tag[3:]),
                     parsed))
         if not has_dynamic_sections:
             # readelf only prints this if there is at least one segment
@@ -395,7 +394,7 @@ class ReadElf(object):
                               self._format_hex(note['n_offset'], fieldsize=8),
                               self._format_hex(note['n_size'], fieldsize=8)))
                       self._emitline('  Owner                 Data size	Description')
-                      self._emitline('  %s%s %s\t%s' % (
+                      self._emitline('  {0!s}{1!s} {2!s}\t{3!s}'.format(
                           note['n_name'], ' ' * (20 - len(note['n_name'])),
                           self._format_hex(note['n_descsz'], fieldsize=8),
                           describe_note(note)))
@@ -409,7 +408,7 @@ class ReadElf(object):
                 continue
 
             has_relocation_sections = True
-            self._emitline("\nRelocation section '%s' at offset %s contains %s entries:" % (
+            self._emitline("\nRelocation section '{0!s}' at offset {1!s} contains {2!s} entries:".format(
                 section.name,
                 self._format_hex(section['sh_offset']),
                 section.num_relocations()))
@@ -423,7 +422,7 @@ class ReadElf(object):
 
             for rel in section.iter_relocations():
                 hexwidth = 8 if self.elffile.elfclass == 32 else 12
-                self._emit('%s  %s %-17.17s' % (
+                self._emit('{0!s}  {1!s} {2:<17.17!s}'.format(
                     self._format_hex(rel['r_offset'],
                         fieldsize=hexwidth, lead0x=False),
                     self._format_hex(rel['r_info'],
@@ -443,14 +442,14 @@ class ReadElf(object):
                     symbol_name = symsec.name
                 else:
                     symbol_name = symbol.name
-                self._emit(' %s %s%22.22s' % (
+                self._emit(' {0!s} {1!s}{2:22.22!s}'.format(
                     self._format_hex(
                         symbol['st_value'],
                         fullhex=True, lead0x=False),
                     '  ' if self.elffile.elfclass == 32 else '',
                     symbol_name))
                 if section.is_RELA():
-                    self._emit(' %s %x' % (
+                    self._emit(' {0!s} {1:x}'.format(
                         '+' if rel['r_addend'] >= 0 else '-',
                         abs(rel['r_addend'])))
                 self._emitline()
@@ -477,7 +476,7 @@ class ReadElf(object):
                 # Symbol version info are printed four by four entries
                 for idx_by_4 in range(0, num_symbols, 4):
 
-                    self._emit('  %03x:' % idx_by_4)
+                    self._emit('  {0:03x}:'.format(idx_by_4))
 
                     for idx in range(idx_by_4, min(idx_by_4 + 4, num_symbols)):
 
@@ -490,11 +489,11 @@ class ReadElf(object):
                             version_name = '(*global*)'
                         else:
                             version_index = symbol_version['index']
-                            version_name = '(%(name)s)' % symbol_version
+                            version_name = '({name!s})'.format(**symbol_version)
 
                         visibility = 'h' if symbol_version['hidden'] else ' '
 
-                        self._emit('%4x%s%-13s' % (
+                        self._emit('{0:4x}{1!s}{2:<13!s}'.format(
                             version_index, visibility, version_name))
 
                     self._emitline()
@@ -525,8 +524,7 @@ class ReadElf(object):
                     verdaux_offset = (
                             offset + verdef['vd_aux'] + verdaux['vda_next'])
                     for idx, verdaux in enumerate(verdaux_iter, start=1):
-                        self._emitline('  %s: Parent %i: %s' %
-                            (self._format_hex(verdaux_offset, fieldsize=4),
+                        self._emitline('  {0!s}: Parent {1:d}: {2!s}'.format(self._format_hex(verdaux_offset, fieldsize=4),
                                               idx, verdaux.name))
                         verdaux_offset += verdaux['vda_next']
 
@@ -538,7 +536,7 @@ class ReadElf(object):
                 offset = 0
                 for verneed, verneed_iter in section.iter_versions():
 
-                    self._emitline('  %s: Version: %i  File: %s  Cnt: %i' % (
+                    self._emitline('  {0!s}: Version: {1:d}  File: {2!s}  Cnt: {3:d}'.format(
                             self._format_hex(offset, fieldsize=6,
                                              alternate=True),
                             verneed['vn_version'], verneed.name,
@@ -554,7 +552,7 @@ class ReadElf(object):
                             flags = 'none'
 
                         self._emitline(
-                            '  %s:   Name: %s  Flags: %s  Version: %i' % (
+                            '  {0!s}:   Name: {1!s}  Flags: {2!s}  Version: {3:d}'.format(
                                 self._format_hex(vernaux_offset, fieldsize=4),
                                 vernaux.name, flags,
                                 vernaux['vna_other']))
@@ -569,11 +567,11 @@ class ReadElf(object):
         """
         section = self._section_from_spec(section_spec)
         if section is None:
-            self._emitline("Section '%s' does not exist in the file!" % (
-                section_spec))
+            self._emitline("Section '{0!s}' does not exist in the file!".format((
+                section_spec)))
             return
 
-        self._emitline("\nHex dump of section '%s':" % section.name)
+        self._emitline("\nHex dump of section '{0!s}':".format(section.name))
         self._note_relocs_for_section(section)
         addr = section['sh_addr']
         data = section.data()
@@ -584,10 +582,10 @@ class ReadElf(object):
             # chunks of 16 bytes per line
             linebytes = 16 if bytesleft > 16 else bytesleft
 
-            self._emit('  %s ' % self._format_hex(addr, fieldsize=8))
+            self._emit('  {0!s} '.format(self._format_hex(addr, fieldsize=8)))
             for i in range(16):
                 if i < linebytes:
-                    self._emit('%2.2x' % byte2int(data[dataptr + i]))
+                    self._emit('{0:2.2x}'.format(byte2int(data[dataptr + i])))
                 else:
                     self._emit('  ')
                 if i % 4 == 3:
@@ -612,11 +610,11 @@ class ReadElf(object):
         """
         section = self._section_from_spec(section_spec)
         if section is None:
-            self._emitline("Section '%s' does not exist in the file!" % (
-                section_spec))
+            self._emitline("Section '{0!s}' does not exist in the file!".format((
+                section_spec)))
             return
 
-        self._emitline("\nString dump of section '%s':" % section.name)
+        self._emitline("\nString dump of section '{0!s}':".format(section.name))
 
         found = False
         data = section.data()
@@ -635,7 +633,7 @@ class ReadElf(object):
                 endptr += 1
 
             found = True
-            self._emitline('  [%6x]  %s' % (
+            self._emitline('  [{0:6x}]  {1!s}'.format(
                 dataptr, bytes2str(data[dataptr:endptr])))
 
             dataptr = endptr
@@ -663,7 +661,7 @@ class ReadElf(object):
         elif dump_what == 'frames-interp':
             self._dump_debug_frames_interp()
         else:
-            self._emitline('debug dump not yet supported for "%s"' % dump_what)
+            self._emitline('debug dump not yet supported for "{0!s}"'.format(dump_what))
 
     def _format_hex(self, addr, fieldsize=None, fullhex=False, lead0x=True,
                     alternate=False):
@@ -701,7 +699,7 @@ class ReadElf(object):
         if fieldsize is None:
             field = '%x'
         else:
-            field = '%' + '0%sx' % fieldsize
+            field = '%' + '0{0!s}x'.format(fieldsize)
         return s + field % addr
 
     def _print_version_section_header(self, version_section, name, lead0x=True,
@@ -716,9 +714,8 @@ class ReadElf(object):
         else:
             num_entries = version_section.num_symbols()
 
-        self._emitline("\n%s section '%s' contains %s entries:" %
-            (name, version_section.name, num_entries))
-        self._emitline('%sAddr: %s  Offset: %s  Link: %i (%s)' % (
+        self._emitline("\n{0!s} section '{1!s}' contains {2!s} entries:".format(name, version_section.name, num_entries))
+        self._emitline('{0!s}Addr: {1!s}  Offset: {2!s}  Link: {3:d} ({4!s})'.format(
             ' ' * indent,
             self._format_hex(
                 version_section['sh_addr'], fieldsize=16, lead0x=lead0x),
@@ -841,15 +838,15 @@ class ReadElf(object):
         section_offset = self._dwarfinfo.debug_info_sec.global_offset
 
         for cu in self._dwarfinfo.iter_CUs():
-            self._emitline('  Compilation Unit @ offset %s:' %
-                self._format_hex(cu.cu_offset))
-            self._emitline('   Length:        %s (%s)' % (
+            self._emitline('  Compilation Unit @ offset {0!s}:'.format(
+                self._format_hex(cu.cu_offset)))
+            self._emitline('   Length:        {0!s} ({1!s})'.format(
                 self._format_hex(cu['unit_length']),
-                '%s-bit' % cu.dwarf_format()))
-            self._emitline('   Version:       %s' % cu['version']),
-            self._emitline('   Abbrev Offset: %s' % (
-                self._format_hex(cu['debug_abbrev_offset']))),
-            self._emitline('   Pointer Size:  %s' % cu['address_size'])
+                '{0!s}-bit'.format(cu.dwarf_format())))
+            self._emitline('   Version:       {0!s}'.format(cu['version'])),
+            self._emitline('   Abbrev Offset: {0!s}'.format((
+                self._format_hex(cu['debug_abbrev_offset'])))),
+            self._emitline('   Pointer Size:  {0!s}'.format(cu['address_size']))
 
             # The nesting depth of each DIE within the tree of DIEs must be
             # displayed. To implement this, a counter is incremented each time
@@ -859,11 +856,11 @@ class ReadElf(object):
             #
             die_depth = 0
             for die in cu.iter_DIEs():
-                self._emitline(' <%s><%x>: Abbrev Number: %s%s' % (
+                self._emitline(' <{0!s}><{1:x}>: Abbrev Number: {2!s}{3!s}'.format(
                     die_depth,
                     die.offset,
                     die.abbrev_code,
-                    (' (%s)' % die.tag) if not die.is_null() else ''))
+                    (' ({0!s})'.format(die.tag)) if not die.is_null() else ''))
                 if die.is_null():
                     die_depth -= 1
                     continue
@@ -872,8 +869,8 @@ class ReadElf(object):
                     name = attr.name
                     # Unknown attribute values are passed-through as integers
                     if isinstance(name, int):
-                        name = 'Unknown AT value: %x' % name
-                    self._emitline('    <%x>   %-18s: %s' % (
+                        name = 'Unknown AT value: {0:x}'.format(name)
+                    self._emitline('    <{0:x}>   {1:<18!s}: {2!s}'.format(
                         attr.offset,
                         name,
                         describe_attr_value(
@@ -900,9 +897,9 @@ class ReadElf(object):
                     dir = lineprogram['include_directory'][dir_index - 1]
                 else:
                     dir = b'.'
-                cu_filename = '%s/%s' % (bytes2str(dir), cu_filename)
+                cu_filename = '{0!s}/{1!s}'.format(bytes2str(dir), cu_filename)
 
-            self._emitline('CU: %s:' % cu_filename)
+            self._emitline('CU: {0!s}:'.format(cu_filename))
             self._emitline('File name                            Line number    Starting address')
 
             # Print each state's file, line and address information. For some
@@ -916,27 +913,27 @@ class ReadElf(object):
                         file_entry = lineprogram['file_entry'][entry.args[0] - 1]
                         if file_entry.dir_index == 0:
                             # current directory
-                            self._emitline('\n./%s:[++]' % (
-                                bytes2str(file_entry.name)))
+                            self._emitline('\n./{0!s}:[++]'.format((
+                                bytes2str(file_entry.name))))
                         else:
-                            self._emitline('\n%s/%s:' % (
+                            self._emitline('\n{0!s}/{1!s}:'.format(
                                 bytes2str(lineprogram['include_directory'][file_entry.dir_index - 1]),
                                 bytes2str(file_entry.name)))
                     elif entry.command == DW_LNE_define_file:
-                        self._emitline('%s:' % (
-                            bytes2str(lineprogram['include_directory'][entry.args[0].dir_index])))
+                        self._emitline('{0!s}:'.format((
+                            bytes2str(lineprogram['include_directory'][entry.args[0].dir_index]))))
                 elif not state.end_sequence:
                     # readelf doesn't print the state after end_sequence
                     # instructions. I think it's a bug but to be compatible
                     # I don't print them too.
                     if lineprogram['version'] < 4:
-                        self._emitline('%-35s  %11d  %18s' % (
+                        self._emitline('{0:<35!s}  {1:11d}  {2:18!s}'.format(
                             bytes2str(lineprogram['file_entry'][state.file - 1].name),
                             state.line,
                             '0' if state.address == 0 else
                                 self._format_hex(state.address)))
                     else:
-                        self._emitline('%-35s  %11d  %18s[%d]' % (
+                        self._emitline('{0:<35!s}  {1:11d}  {2:18!s}[{3:d}]'.format(
                             bytes2str(lineprogram['file_entry'][state.file - 1].name),
                             state.line,
                             '0' if state.address == 0 else
@@ -955,18 +952,18 @@ class ReadElf(object):
 
         for entry in self._dwarfinfo.CFI_entries():
             if isinstance(entry, CIE):
-                self._emitline('\n%08x %s %s CIE' % (
+                self._emitline('\n{0:08x} {1!s} {2!s} CIE'.format(
                     entry.offset,
                     self._format_hex(entry['length'], fullhex=True, lead0x=False),
                     self._format_hex(entry['CIE_id'], fullhex=True, lead0x=False)))
-                self._emitline('  Version:               %d' % entry['version'])
-                self._emitline('  Augmentation:          "%s"' % bytes2str(entry['augmentation']))
-                self._emitline('  Code alignment factor: %u' % entry['code_alignment_factor'])
-                self._emitline('  Data alignment factor: %d' % entry['data_alignment_factor'])
-                self._emitline('  Return address column: %d' % entry['return_address_register'])
+                self._emitline('  Version:               {0:d}'.format(entry['version']))
+                self._emitline('  Augmentation:          "{0!s}"'.format(bytes2str(entry['augmentation'])))
+                self._emitline('  Code alignment factor: {0:d}'.format(entry['code_alignment_factor']))
+                self._emitline('  Data alignment factor: {0:d}'.format(entry['data_alignment_factor']))
+                self._emitline('  Return address column: {0:d}'.format(entry['return_address_register']))
                 self._emitline()
             else: # FDE
-                self._emitline('\n%08x %s %s FDE cie=%08x pc=%s..%s' % (
+                self._emitline('\n{0:08x} {1!s} {2!s} FDE cie={3:08x} pc={4!s}..{5!s}'.format(
                     entry.offset,
                     self._format_hex(entry['length'], fullhex=True, lead0x=False),
                     self._format_hex(entry['CIE_pointer'], fullhex=True, lead0x=False),
@@ -989,7 +986,7 @@ class ReadElf(object):
 
         for entry in self._dwarfinfo.CFI_entries():
             if isinstance(entry, CIE):
-                self._emitline('\n%08x %s %s CIE "%s" cf=%d df=%d ra=%d' % (
+                self._emitline('\n{0:08x} {1!s} {2!s} CIE "{3!s}" cf={4:d} df={5:d} ra={6:d}'.format(
                     entry.offset,
                     self._format_hex(entry['length'], fullhex=True, lead0x=False),
                     self._format_hex(entry['CIE_id'], fullhex=True, lead0x=False),
@@ -999,7 +996,7 @@ class ReadElf(object):
                     entry['return_address_register']))
                 ra_regnum = entry['return_address_register']
             else: # FDE
-                self._emitline('\n%08x %s %s FDE cie=%08x pc=%s..%s' % (
+                self._emitline('\n{0:08x} {1!s} {2!s} FDE cie={3:08x} pc={4!s}..{5!s}'.format(
                     entry.offset,
                     self._format_hex(entry['length'], fullhex=True, lead0x=False),
                     self._format_hex(entry['CIE_pointer'], fullhex=True, lead0x=False),
@@ -1026,7 +1023,7 @@ class ReadElf(object):
 
                 # Headings for the registers
                 for regnum in reg_order:
-                    self._emit('%-6s' % describe_reg_name(regnum))
+                    self._emit('{0:<6!s}'.format(describe_reg_name(regnum)))
                 self._emitline('ra      ')
 
                 # Now include ra_regnum in reg_order to print its values similarly
@@ -1038,14 +1035,14 @@ class ReadElf(object):
             for line in decoded_table.table:
                 self._emit(self._format_hex(
                     line['pc'], fullhex=True, lead0x=False))
-                self._emit(' %-9s' % describe_CFI_CFA_rule(line['cfa']))
+                self._emit(' {0:<9!s}'.format(describe_CFI_CFA_rule(line['cfa'])))
 
                 for regnum in reg_order:
                     if regnum in line:
                         s = describe_CFI_register_rule(line[regnum])
                     else:
                         s = 'u'
-                    self._emit('%-6s' % s)
+                    self._emit('{0:<6!s}'.format(s))
                 self._emitline()
         self._emitline()
 
@@ -1061,7 +1058,7 @@ class ReadElf(object):
 
 
 SCRIPT_DESCRIPTION = 'Display information about the contents of ELF format files'
-VERSION_STRING = '%%prog: based on pyelftools %s' % __version__
+VERSION_STRING = '%prog: based on pyelftools {0!s}'.format(__version__)
 
 
 def main(stream=None):
@@ -1155,7 +1152,7 @@ def main(stream=None):
             if options.debug_dump_what:
                 readelf.display_debug_dump(options.debug_dump_what)
         except ELFError as ex:
-            sys.stderr.write('ELF error: %s\n' % ex)
+            sys.stderr.write('ELF error: {0!s}\n'.format(ex))
             sys.exit(1)
 
 

--- a/test/all_tests.py
+++ b/test/all_tests.py
@@ -13,7 +13,7 @@ from utils import is_in_rootdir
 
 def run_test_script(path):
     cmd = [sys.executable, path]
-    print("Running '%s'" % ' '.join(cmd))
+    print("Running '{0!s}'".format(' '.join(cmd)))
     subprocess.check_call(cmd)
 
 def main():

--- a/test/run_examples_test.py
+++ b/test/run_examples_test.py
@@ -40,7 +40,7 @@ def reference_output_path(example_path):
 
 
 def run_example_and_compare(example_path):
-    testlog.info("Example '%s'" % example_path)
+    testlog.info("Example '{0!s}'".format(example_path))
 
     reference_path = reference_output_path(example_path)
     ref_str = ''
@@ -48,13 +48,13 @@ def run_example_and_compare(example_path):
         with open(reference_path) as ref_f:
             ref_str = ref_f.read()
     except (IOError, OSError) as e:
-        testlog.info('.......ERROR - reference output cannot be read! - %s' % e)
+        testlog.info('.......ERROR - reference output cannot be read! - {0!s}'.format(e))
         return False
 
     rc, example_out = run_exe(example_path, ['--test',
                                              './examples/sample_exe64.elf'])
     if rc != 0:
-        testlog.info('.......ERROR - example returned error code %s' % rc)
+        testlog.info('.......ERROR - example returned error code {0!s}'.format(rc))
         return False
 
     # Comparison is done as lists of lines, to avoid EOL problems

--- a/test/run_readelf_tests.py
+++ b/test/run_readelf_tests.py
@@ -44,22 +44,22 @@ def run_test_on_file(filename, verbose=False):
         runs succeeded.
     """
     success = True
-    testlog.info("Test file '%s'" % filename)
+    testlog.info("Test file '{0!s}'".format(filename))
     for option in [
             '-e', '-d', '-s', '-n', '-r', '-x.text', '-p.shstrtab', '-V',
             '--debug-dump=info', '--debug-dump=decodedline',
             '--debug-dump=frames', '--debug-dump=frames-interp']:
-        if verbose: testlog.info("..option='%s'" % option)
+        if verbose: testlog.info("..option='{0!s}'".format(option))
         # stdouts will be a 2-element list: output of readelf and output
         # of scripts/readelf.py
         stdouts = []
         for exe_path in [READELF_PATH, 'scripts/readelf.py']:
             args = [option, filename]
-            if verbose: testlog.info("....executing: '%s %s'" % (
+            if verbose: testlog.info("....executing: '{0!s} {1!s}'".format(
                 exe_path, ' '.join(args)))
             rc, stdout = run_exe(exe_path, args)
             if rc != 0:
-                testlog.error("@@ aborting - '%s' returned '%s'" % (exe_path, rc))
+                testlog.error("@@ aborting - '{0!s}' returned '{1!s}'".format(exe_path, rc))
                 return False
             stdouts.append(stdout)
         if verbose: testlog.info('....comparing output...')
@@ -69,7 +69,7 @@ def run_test_on_file(filename, verbose=False):
         else:
             success = False
             testlog.info('.......................FAIL')
-            testlog.info('....for option "%s"' % option)
+            testlog.info('....for option "{0!s}"'.format(option))
             testlog.info('....Output #1 is readelf, Output #2 is pyelftools')
             testlog.info('@@ ' + errmsg)
             dump_output_to_temp_files(testlog, *stdouts)
@@ -111,7 +111,7 @@ def compare_output(s1, s2):
     flag_after_symtable = False
 
     if len(lines1) != len(lines2):
-        return False, 'Number of lines different: %s vs %s' % (
+        return False, 'Number of lines different: {0!s} vs {1!s}'.format(
                 len(lines1), len(lines2))
 
     for i in range(len(lines1)):
@@ -162,7 +162,7 @@ def compare_output(s1, s2):
                         ok = True
                         break
             if not ok:
-                errmsg = 'Mismatch on line #%s:\n>>%s<<\n>>%s<<\n (%r)' % (
+                errmsg = 'Mismatch on line #{0!s}:\n>>{1!s}<<\n>>{2!s}<<\n ({3!r})'.format(
                     i, lines1[i], lines2[i], changes)
                 return False, errmsg
     return True, ''
@@ -183,9 +183,9 @@ def main():
 
     if options.verbose:
         testlog.info('Running in verbose mode')
-        testlog.info('Python executable = %s' % sys.executable)
-        testlog.info('readelf path = %s' % READELF_PATH)
-        testlog.info('Given list of files: %s' % args)
+        testlog.info('Python executable = {0!s}'.format(sys.executable))
+        testlog.info('readelf path = {0!s}'.format(READELF_PATH))
+        testlog.info('Given list of files: {0!s}'.format(args))
 
     # If file names are given as command-line arguments, only these files
     # are taken as inputs. Otherwise, autodiscovery is performed.

--- a/test/utils.py
+++ b/test/utils.py
@@ -53,5 +53,5 @@ def dump_output_to_temp_files(testlog, *args):
         file = os.fdopen(fd, 'w')
         file.write(s)
         file.close()
-        testlog.info('@@ Output #%s dumped to file: %s' % (i + 1, path))
+        testlog.info('@@ Output #{0!s} dumped to file: {1!s}'.format(i + 1, path))
 

--- a/z.py
+++ b/z.py
@@ -22,7 +22,7 @@ stream = open('test/testfiles/exe_simple64.elf', 'rb')
 
 efile = ELFFile(stream)
 print('elfclass', efile.elfclass)
-print('===> %s sections!' % efile.num_sections())
+print('===> {0!s} sections!'.format(efile.num_sections()))
 print(efile.header)
 
 dinfo = efile.get_dwarf_info()


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:pyelftools?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:pyelftools?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
